### PR TITLE
Check for element availability with variables as selector and marker

### DIFF
--- a/__tests__/src/core/actions/assert.test.js
+++ b/__tests__/src/core/actions/assert.test.js
@@ -197,10 +197,6 @@ describe('assert action test suite', () => {
       },
     };
 
-    when(element.isDisplayed)
-      .calledWith()
-      .mockReturnValue(true);
-
     const selector = uuid();
     const parsedSelector = buildRegexFromParamString(selector);
     const returnMultiple = true;

--- a/__tests__/src/core/actions/assert.test.js
+++ b/__tests__/src/core/actions/assert.test.js
@@ -3,6 +3,11 @@ const { when } = require('jest-when');
 const assert = require('../../../../src/core/actions/assert').common;
 const store = require('../../../../src/core/helpers/dataStore').store();
 const logger = require('../../../../src/utils/logger');
+const { findElements } = require('../../../../src/utils/browser/elementFinder');
+const { buildRegexFromParamString } = require('../../../../src/utils/buildRegex');
+const { eraseHighlights } = require('../../../../src/utils/browser/eraser');
+const { checkElementAvailability } = require('../../../../src/core/actions/assert');
+
 const sampleResp = require('../../../__mocks__/sampleResp.json');
 const { ASSERTION, MESSAGE_TYPE } = require('../../../../src/constants');
 
@@ -175,5 +180,260 @@ describe('assert action test suite', () => {
     expect(store.getGlobal).toHaveBeenCalledTimes(1);
     expect(store.getGlobal).toHaveBeenCalledWith(storeKey);
     expect(logger.emitLogs).toHaveBeenCalledWith({ message: ASSERTION.FAIL, type: MESSAGE_TYPE.INFO });
+  });
+
+  test('assert command should emit an information message with text "TRUE" if the "is available" assertion is true when accessing object properties', async () => {
+    const element = {
+      isDisplayed: jest.fn().mockResolvedValue(true),
+    };
+    const state = {
+      browser: {
+        waitUntil: jest.fn((fn) => fn()),
+        execute: jest.fn().mockResolvedValue({
+          success: true,
+          targetResults: [uuid()],
+        }),
+        $: jest.fn().mockResolvedValue(element),
+      },
+    };
+
+    when(element.isDisplayed)
+      .calledWith()
+      .mockReturnValue(true);
+
+    const selector = uuid();
+    const parsedSelector = buildRegexFromParamString(selector);
+    const returnMultiple = true;
+    const highlightMatch = false;
+    const innerHTMLOnly = false;
+    logger.emitLogs = jest.fn();
+
+    await checkElementAvailability(
+      state,
+      {
+        isAvailable: true,
+      },
+      {
+        args: {
+          selector,
+        },
+      },
+    );
+
+    expect(state.browser.execute).toHaveBeenCalledWith(eraseHighlights);
+    expect(state.browser.execute).toHaveBeenCalledWith(
+      findElements,
+      parsedSelector,
+      undefined,
+      returnMultiple,
+      highlightMatch,
+      innerHTMLOnly,
+    );
+    expect(logger.emitLogs).toHaveBeenCalledWith({
+      message: ASSERTION.PASS,
+      type: MESSAGE_TYPE.INFO,
+    });
+  });
+
+  test('assert command should emit an information message with text "TRUE" if the "is not available" assertion is true when accessing object properties', async () => {
+    const element = {
+      isDisplayed: jest.fn().mockResolvedValue(false),
+    };
+    const state = {
+      browser: {
+        waitUntil: jest.fn((fn) => fn()),
+        execute: jest.fn().mockResolvedValue({
+          success: true,
+          targetResults: [uuid()],
+        }),
+        $: jest.fn().mockResolvedValue(element),
+      },
+    };
+
+    const selector = uuid();
+    const parsedSelector = buildRegexFromParamString(selector);
+    const returnMultiple = true;
+    const highlightMatch = false;
+    const innerHTMLOnly = false;
+    logger.emitLogs = jest.fn();
+
+    await checkElementAvailability(
+      state,
+      {
+        isAvailable: false,
+      },
+      {
+        args: {
+          selector,
+        },
+      },
+    );
+
+    expect(state.browser.execute).toHaveBeenCalledWith(eraseHighlights);
+    expect(state.browser.execute).toHaveBeenCalledWith(
+      findElements,
+      parsedSelector,
+      undefined,
+      returnMultiple,
+      highlightMatch,
+      innerHTMLOnly,
+    );
+    expect(logger.emitLogs).toHaveBeenCalledWith({
+      message: ASSERTION.PASS,
+      type: MESSAGE_TYPE.INFO,
+    });
+  });
+
+  test('assert command should emit an information message with text "TRUE" if the "is available" assertion is true when accessing object properties near marker', async () => {
+    const element = {
+      isDisplayed: jest.fn().mockResolvedValue(true),
+    };
+    const state = {
+      browser: {
+        waitUntil: jest.fn((fn) => fn()),
+        execute: jest.fn().mockResolvedValue({
+          success: true,
+          targetResults: [uuid()],
+        }),
+        $: jest.fn().mockResolvedValue(element),
+      },
+    };
+
+    const selector = uuid();
+    const parsedSelector = buildRegexFromParamString(selector);
+    const marker = uuid();
+    const returnMultiple = true;
+    const highlightMatch = false;
+    const innerHTMLOnly = false;
+    logger.emitLogs = jest.fn();
+
+    await checkElementAvailability(
+      state,
+      {
+        isAvailable: true,
+      },
+      {
+        args: {
+          selector,
+          marker,
+        },
+      },
+    );
+
+    expect(state.browser.execute).toHaveBeenCalledWith(eraseHighlights);
+    expect(state.browser.execute).toHaveBeenCalledWith(
+      findElements,
+      parsedSelector,
+      marker,
+      returnMultiple,
+      highlightMatch,
+      innerHTMLOnly,
+    );
+    expect(logger.emitLogs).toHaveBeenCalledWith({
+      message: ASSERTION.PASS,
+      type: MESSAGE_TYPE.INFO,
+    });
+  });
+
+  test('assert command should emit an information message with text "TRUE" if the "is not available" assertion is true when accessing object properties near marker', async () => {
+    const element = {
+      isDisplayed: jest.fn().mockResolvedValue(false),
+    };
+    const state = {
+      browser: {
+        waitUntil: jest.fn((fn) => fn()),
+        execute: jest.fn().mockResolvedValue({
+          success: true,
+          targetResults: [uuid()],
+        }),
+        $: jest.fn().mockResolvedValue(element),
+      },
+    };
+
+    const selector = uuid();
+    const parsedSelector = buildRegexFromParamString(selector);
+    const marker = uuid();
+    const returnMultiple = true;
+    const highlightMatch = false;
+    const innerHTMLOnly = false;
+    logger.emitLogs = jest.fn();
+
+    await checkElementAvailability(
+      state,
+      {
+        isAvailable: false,
+      },
+      {
+        args: {
+          selector,
+          marker,
+        },
+      },
+    );
+
+    expect(state.browser.execute).toHaveBeenCalledWith(eraseHighlights);
+    expect(state.browser.execute).toHaveBeenCalledWith(
+      findElements,
+      parsedSelector,
+      marker,
+      returnMultiple,
+      highlightMatch,
+      innerHTMLOnly,
+    );
+    expect(logger.emitLogs).toHaveBeenCalledWith({
+      message: ASSERTION.PASS,
+      type: MESSAGE_TYPE.INFO,
+    });
+  });
+
+  test('assert command should emit an information message with text "FALSE" if the "is not available" assertion is false when accessing object properties near marker', async () => {
+    const element = {
+      isDisplayed: jest.fn().mockResolvedValue(true),
+    };
+    const state = {
+      browser: {
+        waitUntil: jest.fn((fn) => fn()),
+        execute: jest.fn().mockResolvedValue({
+          success: true,
+          targetResults: [uuid()],
+        }),
+        $: jest.fn().mockResolvedValue(element),
+      },
+    };
+
+    const selector = uuid();
+    const parsedSelector = buildRegexFromParamString(selector);
+    const marker = uuid();
+    const returnMultiple = true;
+    const highlightMatch = false;
+    const innerHTMLOnly = false;
+    logger.emitLogs = jest.fn();
+
+    await checkElementAvailability(
+      state,
+      {
+        isAvailable: false,
+      },
+      {
+        args: {
+          selector,
+          marker,
+        },
+      },
+    );
+
+    expect(state.browser.execute).toHaveBeenCalledWith(eraseHighlights);
+    expect(state.browser.execute).toHaveBeenCalledWith(
+      findElements,
+      parsedSelector,
+      marker,
+      returnMultiple,
+      highlightMatch,
+      innerHTMLOnly,
+    );
+    expect(logger.emitLogs).toHaveBeenCalledWith({
+      message: ASSERTION.FAIL,
+      type: MESSAGE_TYPE.INFO,
+    });
   });
 });

--- a/kasaya.js
+++ b/kasaya.js
@@ -397,6 +397,22 @@ app.addCommand({
   handler: assert.checkElementAvailability.bind(null, state, { isAvailable: false }),
 });
 app.addCommand({
+  command: 'check if $selector near $marker is available',
+  help:
+    'check if "Out of Stock" near "Products" is available - Checks if "Out of Stock" near "Products" is within current window',
+  handler: assert.checkElementAvailability.bind(null, state, {
+    isAvailable: true,
+  }),
+});
+app.addCommand({
+  command: 'check if $selector near $marker is not available',
+  help:
+    'check if "Out of Stock" near "Products" is not available - Checks if "Out of Stock" near "Products" is not within current window',
+  handler: assert.checkElementAvailability.bind(null, state, {
+    isAvailable: false,
+  }),
+});
+app.addCommand({
   command: 'check if $actualVal is $expectedVal',
   help: 'check if $age is "25" - Checks whether a given value is equal to a previously saved value',
   handler: assert.common,

--- a/src/core/actions/assert.js
+++ b/src/core/actions/assert.js
@@ -193,7 +193,7 @@ const checkElementStatus = async (state, {
   }
 };
 
-const checkElementAvailability = async (state, { isAvailable }, { args: { selector } }) => {
+const checkElementAvailability = async (state, { isAvailable }, { args: { selector, marker } }) => {
   const browser = await validateBrowser(state);
   if (browser) {
     if (selector) {
@@ -213,7 +213,7 @@ const checkElementAvailability = async (state, { isAvailable }, { args: { select
           result = await browser.execute(
             findElements,
             selectorText,
-            undefined,
+            marker,
             elementFinderOpts.returnMultiple,
             elementFinderOpts.highlightMatches,
             elementFinderOpts.innerHTMLOnly,

--- a/src/core/actions/assert.js
+++ b/src/core/actions/assert.js
@@ -203,7 +203,17 @@ const checkElementAvailability = async (state, { isAvailable }, { args: { select
         innerHTMLOnly: false,
       };
 
-      const selectorText = buildRegexFromParamString(selector);
+      const inputs = { selector, marker };
+
+      Object.keys(inputs).forEach((key) => {
+        if (inputs[key] && inputs[key].match(/^\$(?:\w*)/)) {
+          inputs[key] = store.getGlobal(inputs[key]);
+        }
+      });
+      const selectorValue = inputs.selector;
+      const markerValue = inputs.marker;
+
+      const selectorText = buildRegexFromParamString(selectorValue);
       await browser.execute(eraseHighlights);
 
       let result;
@@ -213,7 +223,7 @@ const checkElementAvailability = async (state, { isAvailable }, { args: { select
           result = await browser.execute(
             findElements,
             selectorText,
-            marker,
+            markerValue,
             elementFinderOpts.returnMultiple,
             elementFinderOpts.highlightMatches,
             elementFinderOpts.innerHTMLOnly,


### PR DESCRIPTION
Changes to support variables in the "check element availablity" commands for both selector and marker. Added new tests.